### PR TITLE
[#23] + [#21] Make sounds belong to users and enable fetching of a user's sounds

### DIFF
--- a/api/app/controllers/sounds_controller.rb
+++ b/api/app/controllers/sounds_controller.rb
@@ -3,12 +3,22 @@ class SoundsController < ApplicationController
   before_action :authorize_user!, only: [ :update, :destroy ]
 
   def index
-    sounds = Sound.all
+    sounds = Sound.where(user_id: nil) # Fetch only public sounds
+    render json: SoundSerializer.new(sounds).serializable_hash.to_json
+  end
+
+  def my_sounds
+    authenticate_user!
+    sounds = current_user.sounds
     render json: SoundSerializer.new(sounds).serializable_hash.to_json
   end
 
   def show
-    render json: SoundSerializer.new(sound).serializable_hash.to_json
+    if sound.user_id.nil? || (sound.user == current_user)
+      render json: SoundSerializer.new(sound).serializable_hash.to_json
+    else
+      render json: { error: "Not authorized" }, status: :forbidden
+    end
   end
 
   def create

--- a/api/app/controllers/sounds_controller.rb
+++ b/api/app/controllers/sounds_controller.rb
@@ -1,4 +1,7 @@
 class SoundsController < ApplicationController
+  before_action :authenticate_user!, except: [ :index, :show ]
+  before_action :authorize_user!, only: [ :update, :destroy ]
+
   def index
     sounds = Sound.all
     render json: SoundSerializer.new(sounds).serializable_hash.to_json
@@ -10,6 +13,7 @@ class SoundsController < ApplicationController
 
   def create
     sound = Sound.new(sound_params)
+    sound.user = current_user if user_signed_in?
     sound.audio_file.attach(sound_params[:audio_file])
     sound.tag_ids = sound_params[:tag_ids] if sound_params[:tag_ids]
     if sound.save
@@ -40,5 +44,11 @@ class SoundsController < ApplicationController
 
   def sound_params
     params.require(:sound).permit(:name, :audio_file, tag_ids: [])
+  end
+
+  def authorize_user!
+    if sound.user.present? && sound.user != current_user
+      render json: { error: "Not authorized" }, status: :forbidden
+    end
   end
 end

--- a/api/app/models/sound.rb
+++ b/api/app/models/sound.rb
@@ -1,6 +1,7 @@
 class Sound < ApplicationRecord
   has_and_belongs_to_many :tags
   has_one_attached :audio_file
+  belongs_to :user, optional: true
 
   validates :name, presence: true
   validate :audio_file_presence

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true
   validates :username, presence: true, uniqueness: true
+  has_many :sounds
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     registrations: "users/registrations"
   }
   resources :sounds
+  get "my_sounds", to: "sounds#my_sounds"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/api/db/migrate/20250723151941_add_user_to_sounds.rb
+++ b/api/db/migrate/20250723151941_add_user_to_sounds.rb
@@ -1,0 +1,5 @@
+class AddUserToSounds < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :sounds, :user, null: true, foreign_key: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_22_223841) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_23_151941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -46,6 +46,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_223841) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_sounds_on_user_id"
   end
 
   create_table "sounds_tags", id: false, force: :cascade do |t|
@@ -78,4 +80,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_223841) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "sounds", "users"
 end

--- a/api/spec/requests/sounds_spec.rb
+++ b/api/spec/requests/sounds_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe "Sounds API", type: :request do
   let(:audio) { fixture_file_upload(Rails.root.join("spec/fixtures/files/seinfeld_test_audio.mp3"), "audio/mpeg") }
+  let(:user) { User.create!(email: "user@example.com", password: "password123", username: "user1") }
+  let(:auth_headers) do
+    post "/login", params: { user: { email: user.email, password: "password123" } }.to_json, headers: { "Content-Type" => "application/json" }
+    { "Authorization" => response.headers["Authorization"] }
+  end
   let(:valid_attributes) do
     {
       name: "Test Sound",
@@ -28,16 +33,21 @@ RSpec.describe "Sounds API", type: :request do
   end
 
   describe "POST /sounds" do
-    it "creates a sound with an audio file" do
-      post "/sounds", params: { sound: valid_attributes }
+    it "creates a sound with an audio file for the current user" do
+      post "/sounds", params: { sound: valid_attributes }, headers: auth_headers
       expect(response).to have_http_status(:created)
       data = JSON.parse(response.body)["data"]["attributes"]
       expect(data["name"]).to eq("Test Sound")
       expect(data["audio_file_url"]).to be_present
     end
 
+    it "returns unauthorized if not logged in" do
+      post "/sounds", params: { sound: valid_attributes }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
     it "returns errors for missing audio file" do
-      post "/sounds", params: { sound: { name: "No Audio" } }
+      post "/sounds", params: { sound: { name: "No Audio" } }, headers: auth_headers
       expect(response).to have_http_status(:unprocessable_entity)
       expect(JSON.parse(response.body)["errors"]).to be_present
       expect(JSON.parse(response.body)["errors"]["audio_file"]).to include("must be attached")
@@ -45,20 +55,36 @@ RSpec.describe "Sounds API", type: :request do
   end
 
   describe "PATCH /sounds/:id" do
-    it "updates a sound name" do
-      sound = Sound.create!(name: "Old Name", audio_file: audio)
-      patch "/sounds/#{sound.id}", params: { sound: { name: "New Name" } }
+    it "updates a sound name if owner" do
+      post "/sounds", params: { sound: valid_attributes }, headers: auth_headers
+      sound_id = JSON.parse(response.body)["data"]["id"]
+      patch "/sounds/#{sound_id}", params: { sound: { name: "New Name" } }, headers: auth_headers
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)["data"]["attributes"]["name"]).to eq("New Name")
+    end
+
+    it "returns forbidden if not owner" do
+      other_user = User.create!(email: "other@example.com", password: "password123", username: "otheruser")
+      sound = Sound.create!(name: "Not my sound", audio_file: audio, user: other_user)
+      patch "/sounds/#{sound.id}", params: { sound: { name: "Attempted Rename" } }, headers: auth_headers
+      expect(response).to have_http_status(:forbidden)
     end
   end
 
   describe "DELETE /sounds/:id" do
-    it "deletes a sound" do
-      sound = Sound.create!(name: "Delete Me", audio_file: audio)
-      delete "/sounds/#{sound.id}"
+    it "deletes a sound if owner" do
+      post "/sounds", params: { sound: valid_attributes }, headers: auth_headers
+      sound_id = JSON.parse(response.body)["data"]["id"]
+      delete "/sounds/#{sound_id}", headers: auth_headers
       expect(response).to have_http_status(:no_content)
-      expect(Sound.find_by(id: sound.id)).to be_nil
+      expect(Sound.find_by(id: sound_id)).to be_nil
+    end
+
+    it "returns forbidden if not owner" do
+      other_user = User.create!(email: "other@example.com", password: "password123", username: "otheruser")
+      sound = Sound.create!(name: "Not my sound", audio_file: audio, user: other_user)
+      delete "/sounds/#{sound.id}", headers: auth_headers
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/extension/src/entrypoints/popup/App.tsx
+++ b/extension/src/entrypoints/popup/App.tsx
@@ -4,6 +4,7 @@ import { PublicPath } from "wxt/browser";
 import { postMessage, playLocalAudio, stopLocalAudio } from "@/utils";
 import { storage } from "#imports";
 import { CrossFunctions } from "@/utils/constants";
+import { login, getMySounds } from '@/utils/api';
 
 function App() {
   const [currentlyPlaying, setCurrentlyPlaying] = useState("");
@@ -14,6 +15,18 @@ function App() {
   const micMutedStorage = storage.defineItem<boolean>("session:micMuted", {
     fallback: false,
   });
+
+  const handleTestLogin = async () => {
+    console.log("Testing login...");
+    try {
+      const jwt = await login('natalietest@example.com', 'password123');
+      console.log('JWT:', jwt);
+      const sounds = await getMySounds();
+      console.log('My Sounds:', sounds);
+    } catch (err) {
+      console.error('Login failed:', err);
+    }
+  };
 
   const [fxVolume, setFxVolume] = useState(25);
   const [micMuted, setMicMuted] = useState(false);
@@ -202,6 +215,7 @@ function App() {
               onChange={(e) => handleMicMute(e.target.checked)}
             />
           </label>
+          <button onClick={handleTestLogin}>Test Login</button>
           <button onClick={stopSound}>Stop Sounds</button>
         </div>
         <p style={{ color: isMeet ? "green" : "red" }}>

--- a/extension/src/utils/api.ts
+++ b/extension/src/utils/api.ts
@@ -1,0 +1,24 @@
+export async function login(email: string, password: string) {
+  const res = await fetch('http://localhost:3001/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user: { email, password } }),
+  });
+  const data = await res.json();
+  if (res.ok && res.headers.get('Authorization')) {
+    const jwt = res.headers.get('Authorization').replace('Bearer ', '');
+    await browser.storage.local.set({ jwt });
+    return jwt;
+  }
+  throw new Error(data.status?.message || 'Login failed');
+}
+
+export async function getMySounds() {
+  const { jwt } = await browser.storage.local.get('jwt');
+  if (!jwt) throw new Error('Not logged in');
+  const res = await fetch('http://localhost:3001/my_sounds', {
+    headers: { Authorization: `Bearer ${jwt}` }
+  });
+  if (!res.ok) throw new Error('Failed to fetch sounds');
+  return res.json();
+}


### PR DESCRIPTION
Set up the relationship between sounds and users (sounds belong to a user, user is null if it's a public/default sound), and created a controller action `my_sounds` in order to get the private sounds of a user, whereas `index` gets the default/public sounds. I updated the sounds spec to reflect these changes.
I also made some starter functions in the extension for `login` and `getmysounds` and created a button to test this functionality (the extension can connect to the API! Yay!)