### PR TITLE
[#44] Tags Controller for CRUD actions

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -50,6 +50,8 @@ group :development, :test do
   gem "ruby-lsp"
   gem "rspec-rails"
   gem "simplecov"
+  gem "factory_bot_rails", "~> 6.5"
+  gem "faker"
 end
 
 gem "aws-sdk-s3", "~> 1.193"

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -140,6 +140,13 @@ GEM
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
+    factory_bot (6.5.4)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.0)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
+    faker (3.5.2)
+      i18n (>= 1.8.11, < 2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -411,6 +418,8 @@ DEPENDENCIES
   devise (~> 4.9)
   devise-jwt
   dotenv-rails
+  factory_bot_rails (~> 6.5)
+  faker
   jsonapi-serializer
   kamal
   pg (~> 1.5)

--- a/api/app/controllers/tags_controller.rb
+++ b/api/app/controllers/tags_controller.rb
@@ -38,6 +38,6 @@ class TagsController < ApplicationController
   end
 
   def tag_params
-    params.require(:tag).permit(:name)
+    params.require(:tag).permit(:name, :color)
   end
 end

--- a/api/app/controllers/tags_controller.rb
+++ b/api/app/controllers/tags_controller.rb
@@ -5,7 +5,6 @@ class TagsController < ApplicationController
   end
 
   def show
-    tag = Tag.find(params[:id])
     render json: TagSerializer.new(tag).serializable_hash.to_json
   end
 

--- a/api/app/controllers/tags_controller.rb
+++ b/api/app/controllers/tags_controller.rb
@@ -1,0 +1,43 @@
+class TagsController < ApplicationController
+  def index
+    tags = Tag.all
+    render json: TagSerializer.new(tags).serializable_hash.to_json
+  end
+
+  def show
+    tag = Tag.find(params[:id])
+    render json: TagSerializer.new(tag).serializable_hash.to_json
+  end
+
+  def create
+    tag = Tag.new(tag_params)
+    if tag.save
+      render json: TagSerializer.new(tag).serializable_hash.to_json, status: :created
+    else
+      render json: { errors: tag.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if tag.update(tag_params)
+      render json: TagSerializer.new(tag).serializable_hash.to_json
+    else
+      render json: { errors: tag.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    tag.destroy
+    head :no_content
+  end
+
+  private
+
+  def tag
+    @tag ||= Tag.find(params[:id])
+  end
+
+  def tag_params
+    params.require(:tag).permit(:name)
+  end
+end

--- a/api/app/serializers/sound_serializer.rb
+++ b/api/app/serializers/sound_serializer.rb
@@ -2,11 +2,12 @@ class SoundSerializer
   include JSONAPI::Serializer
   attributes :name, :user_id, :color, :emoji
 
-  has_many :tags, serializer: TagSerializer
-
   attribute :audio_file_url do |object|
     if object.audio_file.attached?
       Rails.application.routes.url_helpers.rails_blob_url(object.audio_file, only_path: true)
     end
+  end
+  attribute :tags do |object|
+    object.tags.map { |tag| { id: tag.id, name: tag.name } }
   end
 end

--- a/api/app/serializers/tag_serializer.rb
+++ b/api/app/serializers/tag_serializer.rb
@@ -1,4 +1,4 @@
 class TagSerializer
   include JSONAPI::Serializer
-  attributes :id, :name
+  attributes :name
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   }
   resources :sounds
   get "my_sounds", to: "sounds#my_sounds"
+
+  resources :tags
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/api/db/migrate/20250728164640_add_color_to_tags.rb
+++ b/api/db/migrate/20250728164640_add_color_to_tags.rb
@@ -1,0 +1,5 @@
+class AddColorToTags < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tags, :color, :string, null: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_25_220723) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_28_164640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_25_220723) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "color"
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -9,16 +9,16 @@
 #   end
 
 default_sounds = [
-  { name: 'Airhorn', file_path: 'airhorn.mp3', tags: ['Funny'] },
-  { name: 'Anime Wow', file_path: 'anime-wow.mp3', tags: [ 'Funny', 'Positive'] },
-  { name: 'Applause', file_path: 'applause.mp3', tags: ['Positive'] },
-  { name: 'Background Music', file_path: 'bg-music.mp3', tags: ['Positive'] },
-  { name: 'Crickets', file_path: 'crickets.mp3', tags: ['Funny'] },
-  { name: 'Drumroll', file_path: 'drumroll.mp3', tags: ['Funny'] },
-  { name: 'Explosion', file_path: 'explosion.mp3', tags: ['Funny'] },
-  { name: 'Quack', file_path: 'quack.mp3', tags: ['Funny'] },
-  { name: 'Splat', file_path: 'splat.mp3', tags: ['Funny'] },
-  { name: 'Yippee', file_path: 'yippee.mp3', tags: ['Funny', 'Positive'] }
+  { name: 'Airhorn', file_path: 'airhorn.mp3', tags: [ 'Funny' ] },
+  { name: 'Anime Wow', file_path: 'anime-wow.mp3', tags: [ 'Funny', 'Positive' ] },
+  { name: 'Applause', file_path: 'applause.mp3', tags: [ 'Positive' ] },
+  { name: 'Background Music', file_path: 'bg-music.mp3', tags: [ 'Positive' ] },
+  { name: 'Crickets', file_path: 'crickets.mp3', tags: [ 'Funny' ] },
+  { name: 'Drumroll', file_path: 'drumroll.mp3', tags: [ 'Funny' ] },
+  { name: 'Explosion', file_path: 'explosion.mp3', tags: [ 'Funny' ] },
+  { name: 'Quack', file_path: 'quack.mp3', tags: [ 'Funny' ] },
+  { name: 'Splat', file_path: 'splat.mp3', tags: [ 'Funny' ] },
+  { name: 'Yippee', file_path: 'yippee.mp3', tags: [ 'Funny', 'Positive' ] }
 ]
 
 default_tags = [
@@ -26,7 +26,7 @@ default_tags = [
   { name: 'Positive' }
 ]
 
-tag_records = default_tags.map { |t| [t[:name], Tag.find_or_create_by!(name: t[:name])] }.to_h
+tag_records = default_tags.map { |t| [ t[:name], Tag.find_or_create_by!(name: t[:name]) ] }.to_h
 
 default_sounds.each do |sound|
   s = Sound.find_or_create_by!(name: sound[:name]) do |snd|
@@ -38,5 +38,3 @@ default_sounds.each do |sound|
     s.tags << tag_records[tag_name] unless s.tags.include?(tag_records[tag_name])
   end
 end
-
-

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -9,20 +9,34 @@
 #   end
 
 default_sounds = [
-  { name: 'Airhorn', file_path: 'airhorn.mp3' },
-  { name: 'Anime Wow', file_path: 'anime-wow.mp3' },
-  { name: 'Applause', file_path: 'applause.mp3' },
-  { name: 'Background Music', file_path: 'bg-music.mp3' },
-  { name: 'Crickets', file_path: 'crickets.mp3' },
-  { name: 'Drumroll', file_path: 'drumroll.mp3' },
-  { name: 'Explosion', file_path: 'explosion.mp3' },
-  { name: 'Quack', file_path: 'quack.mp3' },
-  { name: 'Splat', file_path: 'splat.mp3' },
-  { name: 'Yippee', file_path: 'yippee.mp3' }
+  { name: 'Airhorn', file_path: 'airhorn.mp3', tags: ['Funny'] },
+  { name: 'Anime Wow', file_path: 'anime-wow.mp3', tags: [ 'Funny', 'Positive'] },
+  { name: 'Applause', file_path: 'applause.mp3', tags: ['Positive'] },
+  { name: 'Background Music', file_path: 'bg-music.mp3', tags: ['Positive'] },
+  { name: 'Crickets', file_path: 'crickets.mp3', tags: ['Funny'] },
+  { name: 'Drumroll', file_path: 'drumroll.mp3', tags: ['Funny'] },
+  { name: 'Explosion', file_path: 'explosion.mp3', tags: ['Funny'] },
+  { name: 'Quack', file_path: 'quack.mp3', tags: ['Funny'] },
+  { name: 'Splat', file_path: 'splat.mp3', tags: ['Funny'] },
+  { name: 'Yippee', file_path: 'yippee.mp3', tags: ['Funny', 'Positive'] }
 ]
 
+default_tags = [
+  { name: 'Funny' },
+  { name: 'Positive' }
+]
+
+tag_records = default_tags.map { |t| [t[:name], Tag.find_or_create_by!(name: t[:name])] }.to_h
+
 default_sounds.each do |sound|
-  Sound.find_or_create_by!(name: sound[:name]) do |s|
-    s.audio_file.attach(io: File.open(Rails.root.join("db", "seeds", "audio", sound[:file_path])), filename: sound[:file_path])
+  s = Sound.find_or_create_by!(name: sound[:name]) do |snd|
+    snd.audio_file.attach(io: File.open(Rails.root.join("db", "seeds", "audio", sound[:file_path])), filename: sound[:file_path])
+  end
+
+  # Associate tags
+  sound[:tags].each do |tag_name|
+    s.tags << tag_records[tag_name] unless s.tags.include?(tag_records[tag_name])
   end
 end
+
+

--- a/api/spec/factories/tags.rb
+++ b/api/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    name { Faker::Lorem.unique.word }
+  end
+end

--- a/api/spec/rails_helper.rb
+++ b/api/spec/rails_helper.rb
@@ -76,4 +76,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end

--- a/api/spec/requests/tag_spec.rb
+++ b/api/spec/requests/tag_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe "Tags API", type: :request do
+  let!(:tags) { create_list(:tag, 3) }
+  let(:tag_id) { tags.first.id }
+
+    let(:valid_attributes) do
+    {
+      name: "Test Tag"
+    }
+  end
+
+  describe "GET /tags" do
+    it "returns all tags" do
+      get "/tags"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["data"].length).to eq(3)
+    end
+  end
+
+  describe "GET /tags/:id" do
+    it "returns a single tag" do
+      get "/tags/#{tag_id}"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["data"]["id"]).to eq(tag_id.to_s)
+    end
+  end
+
+  describe "POST /tags" do
+    let(:valid_attributes) { { tag: { name: "Funny" } } }
+
+    it "creates a tag" do
+      expect {
+        post "/tags", params: valid_attributes
+      }.to change(Tag, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json["data"]["attributes"]["name"]).to eq("Funny")
+    end
+  end
+
+  describe "PATCH /tags/:id" do
+    let(:valid_attributes) { { tag: { name: "Updated Name" } } }
+
+    it "updates the tag" do
+      patch "/tags/#{tag_id}", params: valid_attributes
+      expect(response).to have_http_status(:ok)
+      expect(Tag.find(tag_id).name).to eq("Updated Name")
+    end
+  end
+
+  describe "DELETE /tags/:id" do
+    it "deletes the tag" do
+      tag = Tag.create!(name: "Funny")
+
+    expect {
+      delete "/tags/#{tag.id}"
+    }.to change(Tag, :count).by(-1)
+      expect(response).to have_http_status(:no_content)
+      expect(Tag.find_by(id: tag.id)).to be_nil
+    end
+  end
+end

--- a/api/spec/requests/tag_spec.rb
+++ b/api/spec/requests/tag_spec.rb
@@ -4,12 +4,6 @@ RSpec.describe "Tags API", type: :request do
   let!(:tags) { create_list(:tag, 3) }
   let(:tag_id) { tags.first.id }
 
-    let(:valid_attributes) do
-    {
-      name: "Test Tag"
-    }
-  end
-
   describe "GET /tags" do
     it "returns all tags" do
       get "/tags"
@@ -29,7 +23,7 @@ RSpec.describe "Tags API", type: :request do
   end
 
   describe "POST /tags" do
-    let(:valid_attributes) { { tag: { name: "Funny" } } }
+    let(:valid_attributes) { { tag: { name: "Funny", color: "blue" } } }
 
     it "creates a tag" do
       expect {


### PR DESCRIPTION
Created the tags controller with the basic crud actions. We may need to think about what the use case for these routes actually is / maybe add some sort of authentication for them since users shouldn't be creating tags, it should only be us on the database side (as I started to do manually in seeds.db) or maybe an admin. But with these routes the functionality is available for whatever we choose to do with it!