### PR TITLE
Extension - Fetch sounds from database and cache in browser IndexedDB

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.2",
+    "idb": "^8.0.3",
     "radix-ui": "^1.4.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-icons':
         specifier: ^1.3.2
         version: 1.3.2(react@19.1.0)
+      idb:
+        specifier: ^8.0.3
+        version: 8.0.3
       radix-ui:
         specifier: ^1.4.2
         version: 1.4.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1800,6 +1803,9 @@ packages:
   human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
+
+  idb@8.0.3:
+    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -4612,6 +4618,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@4.3.1: {}
+
+  idb@8.0.3: {}
 
   ieee754@1.2.1: {}
 

--- a/extension/src/entrypoints/inject.ts
+++ b/extension/src/entrypoints/inject.ts
@@ -64,7 +64,7 @@ export default defineUnlistedScript(() => {
 
         async function playSoundEffect(base64: string, volume: number) {
           // Prepare sound‐effect node (but don’t play yet)
-          console.log("(inject.ts)Received sound effect base64:", base64);
+          console.log("(inject.ts)Received sound effect base64");
           const buffer = base64ToArrayBuffer(base64);
           const fxBuffer = await loadEffectBuffer(audioCtx, buffer);
           let fxNode = null;
@@ -141,7 +141,6 @@ export default defineUnlistedScript(() => {
     switch (event.data.command) {
       case CrossFunctions.INJECT_AUDIO:
         console.log("Event received for playing audio:", event.data);
-        console.log("recieved play " + event.data.base64);
         if (window.soundboard.triggerAudio) {
           window.soundboard.triggerAudio(
             event.data.base64,

--- a/extension/src/entrypoints/popup/App.tsx
+++ b/extension/src/entrypoints/popup/App.tsx
@@ -5,7 +5,7 @@ import { postMessage, playLocalAudio, stopLocalAudio } from "@/utils";
 import { storage } from "#imports";
 import { CrossFunctions } from "@/utils/constants";
 import { login, getMySounds, getDefaultSounds } from '@/utils/api';
-import { storeSound, retrieveSound } from '@/utils/db.ts'
+import { storeSound, retrieveSound, isSoundCached } from '@/utils/db.ts'
 
 function App() {
   const [currentlyPlaying, setCurrentlyPlaying] = useState("");
@@ -42,12 +42,15 @@ function App() {
         const { name, color, emoji, audio_file_url } = sound.attributes;
         const fullUrl = `http://localhost:3001${audio_file_url}`;
 
-        const audioResponse = await fetch(fullUrl);
-        const blob = await audioResponse.blob();
-        console.log('blob:', blob);
-
-        console.log("Storing sound in IndexedDB:", id);
-        await storeSound(id, blob);
+        const isCached = await isSoundCached(id);
+        if (!isCached) {
+          const audioResponse = await fetch(fullUrl);
+          const blob = await audioResponse.blob();
+          console.log('Caching new sound:', id);
+          await storeSound(id, blob);
+        } else {
+          console.log('Sound already cached:', id);
+        }
 
         return {
           id: id,

--- a/extension/src/entrypoints/popup/App.tsx
+++ b/extension/src/entrypoints/popup/App.tsx
@@ -42,14 +42,12 @@ function App() {
         const { name, color, emoji, audio_file_url } = sound.attributes;
         const fullUrl = `http://localhost:3001${audio_file_url}`;
 
-        // Fetch the sound file as a Blob
         const audioResponse = await fetch(fullUrl);
         const blob = await audioResponse.blob();
         console.log('blob:', blob);
 
-        // Store it in IndexedDB
         console.log("Storing sound in IndexedDB:", id);
-        await storeSound(id, blob); // assumes `name` is unique key
+        await storeSound(id, blob);
 
         return {
           id: id,
@@ -92,10 +90,10 @@ function App() {
         volume: fxVolume,
       });
     }
-    // const success = await playLocalAudio(id, fxVolume);
-    // if (success) {
-    //   setCurrentlyPlaying(name);
-    // }
+    const success = await playLocalAudio(base64, fxVolume);
+    if (success) {
+      setCurrentlyPlaying(id.toString());
+    }
   }
 
   async function stopSound() {

--- a/extension/src/utils/api.ts
+++ b/extension/src/utils/api.ts
@@ -22,3 +22,9 @@ export async function getMySounds() {
   if (!res.ok) throw new Error('Failed to fetch sounds');
   return res.json();
 }
+
+export async function getDefaultSounds() {
+  const res = await fetch('http://localhost:3001/sounds')
+  if (!res.ok) throw new Error('Failed to fetch default sounds');
+  return res.json();
+}

--- a/extension/src/utils/db.ts
+++ b/extension/src/utils/db.ts
@@ -1,0 +1,18 @@
+import { openDB } from 'idb';
+export async function storeSound(id: string, blob: Blob) {
+  console.log("Storing sound in IndexedDB:", id);
+  const db = await openDB('SoundCacheDB', 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains('sounds')) {
+      db.createObjectStore('sounds');
+  }
+    },
+  });
+  await db.put('sounds', blob, id);
+}
+
+export async function retrieveSound(id: number): Promise<Blob> {
+  const db = await openDB('SoundCacheDB', 1);
+  const blob = await db.get('sounds', id);
+  return blob;
+}

--- a/extension/src/utils/db.ts
+++ b/extension/src/utils/db.ts
@@ -1,6 +1,5 @@
 import { openDB } from 'idb';
 export async function storeSound(id: string, blob: Blob) {
-  console.log("Storing sound in IndexedDB:", id);
   const db = await openDB('SoundCacheDB', 1, {
     upgrade(db) {
       if (!db.objectStoreNames.contains('sounds')) {
@@ -8,11 +7,23 @@ export async function storeSound(id: string, blob: Blob) {
   }
     },
   });
-  await db.put('sounds', blob, id);
+  const existing = await db.get('sounds', id);
+  if (!existing) {
+    console.log("Storing sound in IndexedDB:", id);
+    await db.put('sounds', blob, id);
+  } else {
+    console.log("Sound already cached:", id);
+  }
 }
 
 export async function retrieveSound(id: number): Promise<Blob> {
   const db = await openDB('SoundCacheDB', 1);
   const blob = await db.get('sounds', id);
   return blob;
+}
+
+export async function isSoundCached(id: string): Promise<boolean> {
+  const db = await openDB('SoundCacheDB', 1);
+  const sound = await db.get('sounds', id);
+  return !!sound;
 }

--- a/extension/src/utils/index.ts
+++ b/extension/src/utils/index.ts
@@ -31,12 +31,11 @@ declare global {
   }
 }
 
-export async function playLocalAudio(file: PublicPath, volume: number) {
+export async function playLocalAudio(fileURL: string, volume: number) {
   if (!(await URLIsValid())) {
     return false;
   }
 
-  const fileURL = browser.runtime.getURL(file);
   browser.scripting.executeScript({
     target: { tabId: await getActiveTabID() },
     func: function (

--- a/extension/src/utils/index.ts
+++ b/extension/src/utils/index.ts
@@ -31,7 +31,7 @@ declare global {
   }
 }
 
-export async function playLocalAudio(fileURL: string, volume: number) {
+export async function playLocalAudio(base64Audio: string, volume: number) {
   if (!(await URLIsValid())) {
     return false;
   }
@@ -39,31 +39,57 @@ export async function playLocalAudio(fileURL: string, volume: number) {
   browser.scripting.executeScript({
     target: { tabId: await getActiveTabID() },
     func: function (
-      fileURL: string,
+      base64Audio: string,
       volume: number,
       endCommand: CrossFunctions
     ) {
+      function base64ToBlob(base64: string, mimeType = "audio/mpeg") {
+        const real_base64 = base64.split(',')[1];
+        const byteCharacters = atob(real_base64);
+        const byteArrays = [];
+
+        for (let offset = 0; offset < byteCharacters.length; offset += 512) {
+          const slice = byteCharacters.slice(offset, offset + 512);
+          const byteNumbers = new Array(slice.length);
+          for (let i = 0; i < slice.length; i++) {
+            byteNumbers[i] = slice.charCodeAt(i);
+          }
+          const byteArray = new Uint8Array(byteNumbers);
+          byteArrays.push(byteArray);
+        }
+
+        return new Blob(byteArrays, { type: mimeType });
+      }
+
       if (window.localAudio) {
         const audio = window.localAudio;
         audio.pause();
         audio.remove();
       }
-      const audio = new Audio(fileURL);
-      audio.currentTime = 0;
-      audio.volume = volume / 100;
-      audio.onended = () => {
-        window.postMessage(
-          {
-            command: endCommand,
-          },
-          "*"
-        );
-      };
-      audio.play().catch((err) => console.error("Playback failed:", err));
-      window.localAudio = audio;
+
+      try {
+        const blob = base64ToBlob(base64Audio);
+        const objectUrl = URL.createObjectURL(blob);
+        const audio = new Audio(objectUrl);
+        audio.currentTime = 0;
+        audio.volume = volume / 100;
+        audio.onended = () => {
+          window.postMessage(
+            {
+              command: endCommand,
+            },
+            "*"
+          );
+        };
+        audio.play().catch((err) => console.error("Playback failed:", err));
+        window.localAudio = audio;
+      } catch (e) {
+        console.error("Failed to decode and play base64 audio:", e);
+      }
     },
-    args: [fileURL, volume, CrossFunctions.AUDIO_ENDED],
+    args: [base64Audio, volume, CrossFunctions.AUDIO_ENDED],
   });
+
   return true;
 }
 


### PR DESCRIPTION
Caching! It works! The extension fetches the default sounds and their data every time the pop up opens. The extension also only fetches the sound from active storage when it absolutely needs to if the sound has not been cached before.

Sound blobs get cached in the local browser storage of the popup (indexedDB) with the sound id as a key, then to be accessible to the google meet tab (which doesn't have access to the popup's SoundCacheDB) the audio needs to be converted to base64(sending blobs or arraybuffers directly doesn not work) and sent in a message to inject.ts (where it is then reconstituted as an Array Buffer). For playLocalAudio I also convert it to base64 then back into a blob in order to play it ( I assume I must've had issues just trying to pass a blob into the playLocalAudio function but now I can't quite remember if I did actually try to see if that was possible or if I just used base64 because I had just sent it to the inject_audio message)

All of this converting to base64 and back and sending messages back and forth across the extension pop up and the inject script doesn't feel super elegant, but I do think it works ! 