### PR TITLE
[#67] "Add to Folder" on sound action menu - allows default sounds to be added to custom folders

### DIFF
--- a/ui/src/components/SoundGroup/SoundGroup.tsx
+++ b/ui/src/components/SoundGroup/SoundGroup.tsx
@@ -17,6 +17,7 @@ import { useAuth } from "../../util/auth";
 import {
   DeleteDialog,
   EditDialog,
+  AddToFolderDialog,
   EditFolderDialog,
   SoundButton,
   type EditProps,
@@ -41,7 +42,8 @@ const SoundGroup = ({
   const [currentlyEditingFolder, setCurrentlyEditingFolder] = useState(false);
   const [currentlyEditing, setCurrentlyEditing] = useState(false);
   const [editingSound, setEditingSound] = useState<EditProps>();
-
+  const [addingToFolder, setAddingToFolder] = useState(false);
+  const [addToFolderSound, setAddToFolderSound] = useState<EditProps>();
   const [currentlyDeleting, setCurrentlyDeleting] = useState(false);
   const [deletingObject, setDeletingObject] = useState<{
     name: string;
@@ -199,6 +201,17 @@ const SoundGroup = ({
                   });
                   setCurrentlyEditing(true);
                 }}
+                addToFolderFunction={() => {
+                  setAddToFolderSound({
+                    name: sound.name,
+                    id: sound.id,
+                    emoji: sound.emoji,
+                    color: sound.color,
+                    tags: sound.tags,
+                    folders: sound.folders,
+                  });
+                  setAddingToFolder(true);
+                }}
                 deleteFunction={() => {
                   setDeletingObject({ name: sound.name, id: sound.id });
                   setCurrentlyDeleting(true);
@@ -215,6 +228,11 @@ const SoundGroup = ({
             open={currentlyEditing}
             onOpenChange={setCurrentlyEditing}
             sound={editingSound}
+          />
+          <AddToFolderDialog
+            open={addingToFolder}
+            onOpenChange={setAddingToFolder}
+            sound={addToFolderSound}
           />
 
           <EditFolderDialog

--- a/ui/src/components/reuseable/addToFolderDialog.tsx
+++ b/ui/src/components/reuseable/addToFolderDialog.tsx
@@ -1,0 +1,162 @@
+import { Cross2Icon, UpdateIcon } from "@radix-ui/react-icons";
+import { useMutation } from "@tanstack/react-query";
+import { Dialog, Form } from "radix-ui";
+import { useState, useEffect } from "react";
+import { Button, FolderPicker, TextInput } from ".";
+import { useAuth } from "../../util/auth";
+import { queryClient } from "../../util/db";
+import type { Folder, Tag } from "../../util/types";
+
+interface AddToFolderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sound?: {
+    name: string;
+    id: number | null;
+    emoji: string;
+    color: string;
+    tags: Tag[];
+    folders: Folder[];
+  };
+}
+
+export const AddToFolderDialog = ({
+  open,
+  onOpenChange,
+  sound,
+}: AddToFolderDialogProps) => {
+  const [editingFolders, setEditingFolders] = useState<Folder[]>(
+    sound?.folders || []
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const { fetchWithAuth } = useAuth();
+
+  const updateFoldersMutation = useMutation({
+    mutationFn: async (folders: string[]) => {
+      if (!sound?.id) {
+        throw new Error("No sound ID available");
+      }
+      const soundId = sound.id as number;
+
+      const currentFolderSlugs = sound?.folders.map((f) => f.slug) || [];
+
+      const toAdd = folders.filter(
+        (slug) => !currentFolderSlugs.includes(slug)
+      );
+      const toRemove = currentFolderSlugs.filter(
+        (slug) => !folders.includes(slug)
+      );
+
+      const promises = [
+        ...toAdd.map((folderSlug) =>
+          fetchWithAuth(`/folders/${folderSlug}/add_sound`, {
+            method: "POST",
+            body: (() => {
+              const fd = new FormData();
+              fd.append("sound_id", soundId.toString());
+              return fd;
+            })(),
+          })
+        ),
+        ...toRemove.map((folderSlug) =>
+          fetchWithAuth(`/folders/${folderSlug}/remove_sound`, {
+            method: "DELETE",
+            body: (() => {
+              const fd = new FormData();
+              fd.append("sound_id", soundId.toString());
+              return fd;
+            })(),
+          })
+        ),
+      ];
+
+      await Promise.all(promises);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sounds"] });
+      setIsSaving(false);
+      onOpenChange(false);
+    },
+  });
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSaving(true);
+    const data = Object.fromEntries(new FormData(event.currentTarget));
+    updateFoldersMutation.mutate(JSON.parse(data.folders as string));
+  }
+
+  useEffect(() => {
+    if (open) {
+      setEditingFolders(sound?.folders || []);
+    }
+  }, [open, sound]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="dialogOverlay" />
+        <Dialog.Content className="editDialog">
+          <Dialog.Title className="editDialogTitle">Add to Folder</Dialog.Title>
+
+          <Form.Root onSubmit={handleSubmit}>
+            <Form.Field
+              className="editDialogFieldContainer editDialogFieldContainerSelector"
+              name="folders"
+            >
+              <FolderPicker
+                selectedFolders={editingFolders}
+                setSelectedFolders={setEditingFolders}
+                side="right"
+                align="center"
+                style={{ width: "100%" }}
+              >
+                <Form.Label className="visually-hidden">Folders</Form.Label>
+                <TextInput
+                  disabled
+                  value={
+                    editingFolders.length > 0
+                      ? editingFolders
+                          .map((folder: any) => folder.name)
+                          .join(", ")
+                      : "Select Folders"
+                  }
+                  leftIcon="archive"
+                  rightIcon="chevronRight"
+                  iconSize={32}
+                  className="editDialogInput editDialogInputDisabled"
+                  style={{
+                    textOverflow: "ellipsis",
+                    overflow: "hidden",
+                    whiteSpace: "nowrap",
+                  }}
+                />
+                <Form.Control asChild>
+                  <input
+                    type="hidden"
+                    value={JSON.stringify(
+                      editingFolders.map((folder) => folder.slug)
+                    )}
+                  />
+                </Form.Control>
+              </FolderPicker>
+            </Form.Field>
+
+            <Form.Submit asChild>
+              <Button
+                className="rightAlign editDialogSubmit"
+                disabled={isSaving}
+              >
+                {isSaving ? <UpdateIcon className="spinIcon" /> : "Save"}
+              </Button>
+            </Form.Submit>
+          </Form.Root>
+
+          <Dialog.Close className="tagPickerClose" aria-label="Close">
+            <Cross2Icon className="tagPickerCloseIcon" />
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/ui/src/components/reuseable/button.tsx
+++ b/ui/src/components/reuseable/button.tsx
@@ -50,6 +50,7 @@ export interface SoundButtonProps
     emoji: string
   ) => void;
   deleteFunction: (name: string, dbID: number) => void;
+  addToFolderFunction: () => void;
 }
 
 const SoundButton = ({
@@ -64,6 +65,7 @@ const SoundButton = ({
   withinFolder,
   editFunction,
   deleteFunction,
+  addToFolderFunction,
   className = "",
   ...props
 }: SoundButtonProps) => {
@@ -180,6 +182,13 @@ const SoundButton = ({
                 Favorite
               </DropdownMenu.Item>
             )}
+            <DropdownMenu.Item
+              className="soundButtonMenuItem"
+              onSelect={addToFolderFunction}
+            >
+              <ArchiveIcon className="soundButtonMenuItemIcon" />
+              Add to Folder
+            </DropdownMenu.Item>
             {userSound && (
               <DropdownMenu.Item
                 className="soundButtonMenuItem"

--- a/ui/src/components/reuseable/index.ts
+++ b/ui/src/components/reuseable/index.ts
@@ -1,3 +1,4 @@
+export * from "./addToFolderDialog";
 export * from "./button";
 export * from "./confirmDelete";
 export * from "./editDialog";


### PR DESCRIPTION
Addresses #67 
-Adds a new "Add to Folder" option to the sound button actions dropdown menu, allowing users to quickly assign any sound (including default sounds) to multiple folders without opening the full edit dialog.
-New component called `AddToFolderDialog` which uses same `FolderPicker` from edit dialog. Assigns to folders differently than the edit dialog - uses the `POST /folders/{slug}/add_sound` and `DELETE /folders/{slug}/remove_sound` endpoints (how add and remove favorite works) rather than editing the sound's folders since users don't have the ability to edit default sounds.
-I've attached various screenshots - this was the best solution/design I could think of, but I'm not a huge fan of how when you're within a folder there's both an `add to folder` and `remove from folder` option. Another potential name for `add to folder` could be `edit folders` or something else, since you can add and remove from multiple folders from that model. This set up works fine, but any design ideas are welcome!
<img width="295" height="188" alt="Screenshot 2025-10-03 at 1 11 59 PM" src="https://github.com/user-attachments/assets/6d751eb3-7057-4f2b-99bf-793ad291c04f" />
<img width="267" height="189" alt="Screenshot 2025-10-03 at 1 12 06 PM" src="https://github.com/user-attachments/assets/f4be494e-bc94-432a-8317-3bd72d40dd75" />
<img width="1572" height="787" alt="Screenshot 2025-10-03 at 1 45 24 PM" src="https://github.com/user-attachments/assets/cf57d2ff-94dd-4738-984a-0f067a61be0e" />
<img width="419" height="250" alt="Screenshot 2025-10-03 at 2 03 47 PM" src="https://github.com/user-attachments/assets/7ff83f0e-8486-4c12-91ef-c3fd1f5c8184" />
<img width="757" height="312" alt="Screenshot 2025-10-03 at 2 03 56 PM" src="https://github.com/user-attachments/assets/81bf87a6-b45f-4dfd-91f5-d330f5c116e7" />
